### PR TITLE
Fix pronoun.is href

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -107,7 +107,7 @@
          ", cujo "
          (href "https://pronom.es/ela" "pronome é ela/dela.")]
      [:p "pronom.es é um fork do "
-         (href "pronoun.is" "pronoun.is")
+         (href "https://pronoun.is" "pronoun.is")
          " que é feito por "
          (twitter-name "morganastra")
          ", cujo "


### PR DESCRIPTION
- This PR fix the href link of pronoun.is on the bottom of the page
- Right now it goes to http://www.pronom.es/pronoun.is

*Thanks for contributing! Please check the following things before submitting your PR :)*

  - [ ] PR message includes a link to the relevant issue(s) 💁‍♀️🖇️🧾
  - [ ] Commit messages are well-formatted
  (please follow [this guide](https://chris.beams.io/posts/git-commit/)) 📝📐
  - [ ] New features have test coverage 📋☑️☑️☑️
  - [ ] The app boots and pronoun pages are served correctly 
  (try `lein ring server`) 👩‍💻🚀
